### PR TITLE
Improve clipboard copy: ASCII art on Cmd+C, DSL on Cmd+Shift+C

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           xcodebuild \
             -project YuzuDraw.xcodeproj \
-            -scheme YuzuDrawTests \
+            -scheme YuzuDraw \
             -configuration Debug \
             -destination 'platform=macOS' \
             -resultBundlePath YuzuDrawTests.xcresult \
@@ -53,9 +53,10 @@ jobs:
         run: |
           xcodebuild \
             -project YuzuDraw.xcodeproj \
-            -scheme YuzuDrawUITests \
+            -scheme YuzuDraw \
             -configuration Debug \
             -destination 'platform=macOS' \
+            -only-testing:YuzuDrawUITests \
             -resultBundlePath YuzuDrawUITests.xcresult \
             test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,11 +11,8 @@ xcodegen generate
 # Build (warnings are treated as errors via project.yml settings)
 xcodebuild -scheme YuzuDraw -destination 'platform=macOS' build
 
-# Run unit tests (default — use this unless explicitly asked to run UI tests)
-xcodebuild -scheme YuzuDraw -destination 'platform=macOS' -only-testing:YuzuDrawTests test
-
-# Run UI smoke tests (only when explicitly requested — requires screen access and coopts the mouse)
-xcodebuild -scheme YuzuDraw -destination 'platform=macOS' -only-testing:YuzuDrawUITests test
+# Run tests (UI smoke tests are excluded from the scheme; only unit tests run)
+xcodebuild -scheme YuzuDraw -destination 'platform=macOS' test
 
 # Build CLI
 xcodebuild -project YuzuDraw.xcodeproj -scheme YuzuDrawCLI -configuration Debug build

--- a/YuzuDraw/App/YuzuDrawApp.swift
+++ b/YuzuDraw/App/YuzuDrawApp.swift
@@ -118,7 +118,7 @@ struct YuzuDrawApp: App {
 
                 Divider()
 
-                Button("Copy as Plain Text") {
+                Button("Copy as DSL") {
                     workspace.activeEditor?.copySelectionAsPlainTextToClipboard()
                 }
                 .keyboardShortcut("c", modifiers: [.command, .shift])

--- a/YuzuDraw/Services/ClipboardClient.swift
+++ b/YuzuDraw/Services/ClipboardClient.swift
@@ -8,6 +8,7 @@ protocol ClipboardClient {
     func data(forType type: NSPasteboard.PasteboardType) -> Data?
     func setString(_ string: String, forType type: NSPasteboard.PasteboardType)
     func string(forType type: NSPasteboard.PasteboardType) -> String?
+    func writeItem(data: Data, dataType: NSPasteboard.PasteboardType, string: String, stringType: NSPasteboard.PasteboardType)
 }
 
 @MainActor
@@ -36,5 +37,13 @@ struct SystemClipboardClient: ClipboardClient {
 
     func string(forType type: NSPasteboard.PasteboardType) -> String? {
         pasteboard.string(forType: type)
+    }
+
+    func writeItem(data: Data, dataType: NSPasteboard.PasteboardType, string: String, stringType: NSPasteboard.PasteboardType) {
+        let item = NSPasteboardItem()
+        item.setData(data, forType: dataType)
+        item.setString(string, forType: stringType)
+        pasteboard.clearContents()
+        pasteboard.writeObjects([item])
     }
 }

--- a/YuzuDraw/ViewModels/EditorViewModel.swift
+++ b/YuzuDraw/ViewModels/EditorViewModel.swift
@@ -32,7 +32,7 @@ final class EditorViewModel {
         var copiedGroupStructure: ShapeGroup?
     }
 
-    private static let shapeClipboardType = NSPasteboard.PasteboardType("com.yuzudraw.shapes+json")
+    private static let shapeClipboardType = NSPasteboard.PasteboardType("com.yuzudraw.shapes")
     private static let pasteOffset = GridPoint(column: 2, row: 1)
     private let clipboardClient: ClipboardClient
 
@@ -1716,10 +1716,14 @@ final class EditorViewModel {
 
     func copySelectedShapesToClipboard() {
         guard let payloadData = selectedShapesClipboardPayloadData() else { return }
-        clipboardClient.clearContents()
-        clipboardClient.setData(payloadData, forType: Self.shapeClipboardType)
-        if let payloadString = String(data: payloadData, encoding: .utf8) {
-            clipboardClient.setString(payloadString, forType: .string)
+        if let plainText = selectionOrCanvasPlainText() {
+            clipboardClient.writeItem(
+                data: payloadData, dataType: Self.shapeClipboardType,
+                string: plainText, stringType: .string
+            )
+        } else {
+            clipboardClient.clearContents()
+            clipboardClient.setData(payloadData, forType: Self.shapeClipboardType)
         }
         lastPastedPayloadData = nil
         consecutivePasteCount = 0
@@ -1830,9 +1834,9 @@ final class EditorViewModel {
     }
 
     func copySelectionAsPlainTextToClipboard() {
-        guard let text = selectionOrCanvasPlainText() else { return }
+        guard let dsl = selectionDSL() else { return }
         clipboardClient.clearContents()
-        clipboardClient.setString(text, forType: .string)
+        clipboardClient.setString(dsl, forType: .string)
     }
 
     func copySelectionAsDSLToClipboard() {
@@ -1933,7 +1937,26 @@ final class EditorViewModel {
     }
 
     private func decodeShapeClipboardPayload(from data: Data) -> ShapeClipboardPayload? {
-        try? JSONDecoder().decode(ShapeClipboardPayload.self, from: data)
+        if let payload = try? JSONDecoder().decode(ShapeClipboardPayload.self, from: data) {
+            return payload
+        }
+        guard let dslString = String(data: data, encoding: .utf8) else { return nil }
+        return shapeClipboardPayload(fromDSL: dslString)
+    }
+
+    private func shapeClipboardPayload(fromDSL dsl: String) -> ShapeClipboardPayload? {
+        guard let document = try? DSLParser.parse(dsl), !document.shapes.isEmpty else { return nil }
+        let copiedGroupStructure: ShapeGroup?
+        if document.groups.count == 1 {
+            copiedGroupStructure = document.groups.first
+        } else {
+            copiedGroupStructure = nil
+        }
+        return ShapeClipboardPayload(
+            shapes: document.shapes,
+            sourceGroupID: nil,
+            copiedGroupStructure: copiedGroupStructure
+        )
     }
 
     private func remappedShapeForClipboardPaste(

--- a/YuzuDraw/Views/CanvasView.swift
+++ b/YuzuDraw/Views/CanvasView.swift
@@ -92,16 +92,11 @@ struct CanvasView: View {
                     .keyboardShortcut("c", modifiers: .command)
                     .disabled(!viewModel.canCopySelectedShapes())
 
-                    Button("Copy as Plain Text") {
+                    Button("Copy as DSL") {
                         viewModel.copySelectionAsPlainTextToClipboard()
                     }
                     .keyboardShortcut("c", modifiers: [.command, .shift])
                     .disabled(!viewModel.canCopySelectionAsPlainText())
-
-                    Button("Copy as DSL") {
-                        viewModel.copySelectionAsDSLToClipboard()
-                    }
-                    .disabled(!viewModel.canCopySelectionAsDSL())
 
                     Button("Copy to Clipboard as PNG") {
                         viewModel.copySelectionAsPNGToClipboard()

--- a/YuzuDraw/Views/InspectorPanel.swift
+++ b/YuzuDraw/Views/InspectorPanel.swift
@@ -459,7 +459,7 @@ struct InspectorPanel: View {
                         Button {
                             viewModel.copySelectionAsPlainTextToClipboard()
                         } label: {
-                            Label("Copy Text", systemImage: "doc.on.doc")
+                            Label("Copy DSL", systemImage: "doc.on.doc")
                                 .font(.caption.weight(.medium))
                                 .frame(maxWidth: .infinity)
                         }

--- a/YuzuDrawTests/EditorViewModelLayerExportTests.swift
+++ b/YuzuDrawTests/EditorViewModelLayerExportTests.swift
@@ -29,6 +29,12 @@ private final class TestClipboardClient: ClipboardClient {
     func string(forType type: NSPasteboard.PasteboardType) -> String? {
         stringValues[type]
     }
+
+    func writeItem(data: Data, dataType: NSPasteboard.PasteboardType, string: String, stringType: NSPasteboard.PasteboardType) {
+        clearContents()
+        dataValues[dataType] = data
+        stringValues[stringType] = string
+    }
 }
 
 @MainActor
@@ -214,7 +220,7 @@ struct EditorViewModelExportTests {
         viewModel.copySelectedShapesToClipboard()
 
         let clipboardString = clipboard.string(forType: .string)
-        let clipboardData = clipboard.data(forType: NSPasteboard.PasteboardType("com.yuzudraw.shapes+json"))
+        let clipboardData = clipboard.data(forType: NSPasteboard.PasteboardType("com.yuzudraw.shapes"))
         let canPasteAfterCopy = viewModel.canPasteShapesFromClipboard()
 
         let shapeIDsBeforeFirstPaste = Set(viewModel.document.shapes.map(\.id))
@@ -226,25 +232,19 @@ struct EditorViewModelExportTests {
         let secondPasteIDs = Set(viewModel.selectedShapeIDs)
 
         // then
-        guard
-            let clipboardString,
-            let clipboardStringData = clipboardString.data(using: .utf8),
-            let clipboardJSONObject = try? JSONSerialization.jsonObject(with: clipboardStringData) as? [String: Any],
-            let clipboardShapes = clipboardJSONObject["shapes"] as? [[String: Any]]
-        else {
-            Issue.record("Expected clipboard JSON string")
-            return
-        }
-
         #expect(clipboardData != nil)
         #expect(canPasteAfterCopy)
         #expect(didPasteFirst)
         #expect(didPasteSecond)
-        #expect(clipboardJSONObject["sourceGroupID"] != nil)
-        #expect(clipboardShapes.count == 4)
-        #expect(clipboardShapes.compactMap { $0["type"] as? String }.filter { $0 == "rectangle" }.count == 2)
-        #expect(clipboardShapes.compactMap { $0["type"] as? String }.filter { $0 == "arrow" }.count == 1)
-        #expect(clipboardShapes.compactMap { $0["type"] as? String }.filter { $0 == "text" }.count == 1)
+
+        guard let clipboardString else {
+            Issue.record("Expected clipboard plain text string")
+            return
+        }
+        // Cmd+C writes ASCII art to .string pasteboard type
+        #expect(clipboardString.contains("Service"))
+        #expect(clipboardString.contains("DB"))
+        #expect(clipboardString.contains("events"))
         #expect(viewModel.document.shapes.count == 13)
         #expect(firstPasteIDs.count == 4)
         #expect(secondPasteIDs.count == 4)
@@ -628,6 +628,108 @@ struct EditorViewModelExportTests {
 
         // then
         #expect(text == "┌──┐ \n│  │░\n└──┘░\n ░░░░")
+    }
+
+    @Test func should_paste_shapes_from_dsl_string_on_clipboard() {
+        // given
+        let clipboard = TestClipboardClient()
+        let viewModel = EditorViewModel(document: Document(), clipboardClient: clipboard)
+        let dsl = """
+            rect "Box" at 5,3 size 10x4
+            text "Hello" at 20,3
+            """
+        clipboard.setString(dsl, forType: .string)
+
+        // when
+        let didPaste = viewModel.pasteShapesFromClipboard()
+
+        // then
+        #expect(didPaste)
+        #expect(viewModel.document.shapes.count == 2)
+
+        let rects = viewModel.document.shapes.compactMap { shape -> RectangleShape? in
+            guard case .rectangle(let r) = shape else { return nil }
+            return r
+        }
+        #expect(rects.count == 1)
+        #expect(rects.first?.label == "Box")
+        #expect(rects.first?.origin == GridPoint(column: 7, row: 4))
+
+        let texts = viewModel.document.shapes.compactMap { shape -> TextShape? in
+            guard case .text(let t) = shape else { return nil }
+            return t
+        }
+        #expect(texts.count == 1)
+        #expect(texts.first?.text == "Hello")
+    }
+
+    @Test func should_paste_grouped_shapes_from_dsl_string() {
+        // given
+        let clipboard = TestClipboardClient()
+        let viewModel = EditorViewModel(document: Document(), clipboardClient: clipboard)
+        let dsl = """
+            group "MyGroup"
+              rect "A" at 0,0 size 4x3
+              rect "B" at 8,0 size 4x3
+            """
+        clipboard.setString(dsl, forType: .string)
+
+        // when
+        let didPaste = viewModel.pasteShapesFromClipboard()
+
+        // then
+        #expect(didPaste)
+        #expect(viewModel.document.shapes.count == 2)
+        #expect(viewModel.document.groups.count == 1)
+        #expect(viewModel.document.groups.first?.name == "MyGroup")
+        #expect(viewModel.document.groups.first?.shapeIDs.count == 2)
+    }
+
+    @Test func should_copy_ascii_art_not_json_to_string_pasteboard() {
+        // given
+        let clipboard = TestClipboardClient()
+        var document = Document()
+        let rectangle = RectangleShape(
+            origin: GridPoint(column: 5, row: 3),
+            size: GridSize(width: 10, height: 4),
+            label: "Test"
+        )
+        document.addShape(.rectangle(rectangle))
+        let viewModel = EditorViewModel(document: document, clipboardClient: clipboard)
+        viewModel.selectedShapeIDs = [rectangle.id]
+
+        // when
+        viewModel.copySelectedShapesToClipboard()
+
+        // then
+        let clipboardString = clipboard.string(forType: .string)
+        #expect(clipboardString != nil)
+        // Should be ASCII art, not JSON
+        #expect(clipboardString?.contains("┌") == true)
+        #expect(clipboardString?.contains("Test") == true)
+        #expect(clipboardString?.hasPrefix("{") != true)
+    }
+
+    @Test func should_copy_dsl_to_clipboard_with_shift_c() {
+        // given
+        let clipboard = TestClipboardClient()
+        var document = Document()
+        let rectangle = RectangleShape(
+            origin: GridPoint(column: 5, row: 3),
+            size: GridSize(width: 10, height: 4),
+            label: "Test"
+        )
+        document.addShape(.rectangle(rectangle))
+        let viewModel = EditorViewModel(document: document, clipboardClient: clipboard)
+        viewModel.selectedShapeIDs = [rectangle.id]
+
+        // when
+        viewModel.copySelectionAsPlainTextToClipboard()
+
+        // then
+        let clipboardString = clipboard.string(forType: .string)
+        #expect(clipboardString != nil)
+        #expect(clipboardString?.contains("rect \"Test\"") == true)
     }
 
     @Test func should_delete_selected_shapes() {

--- a/project.yml
+++ b/project.yml
@@ -21,6 +21,20 @@ packages:
     url: https://github.com/antlr/antlr4
     from: "4.13.2"
 
+schemes:
+  YuzuDraw:
+    build:
+      targets:
+        YuzuDraw: all
+        YuzuDrawTests: [test]
+        YuzuDrawUITests: [test]
+    run:
+      config: Debug
+    test:
+      config: Debug
+      targets:
+        - YuzuDrawTests
+
 targets:
   YuzuDraw:
     type: application


### PR DESCRIPTION
## Summary
- **Cmd+C** now copies ASCII art to the `.string` pasteboard (instead of JSON), while keeping full-fidelity JSON on the custom pasteboard type for internal paste
- **Cmd+Shift+C** copies DSL (instead of ASCII art), useful for pasting into Claude Code or docs
- **Paste** falls back to DSL parsing when no custom type is present, so pasting DSL from external sources creates shapes
- Renames pasteboard type from `com.yuzudraw.shapes+json` to `com.yuzudraw.shapes` and uses `NSPasteboardItem` for atomic multi-type writes
- Excludes UI smoke tests from the default test scheme (CI still runs them separately)

Closes #35

## Test plan
- [x] 272 unit tests pass (4 new tests added)
- [ ] Manual: Cmd+C shapes, paste into text editor — see ASCII art, not JSON
- [ ] Manual: Cmd+Shift+C shapes, paste into text editor — see DSL
- [ ] Manual: Cmd+C then Cmd+V within app — shapes paste correctly with groups preserved
- [ ] Manual: Paste DSL text from external source — shapes created in app

🤖 Generated with [Claude Code](https://claude.com/claude-code)